### PR TITLE
Fix dependency name

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,4 +12,4 @@ galaxy_info:
   categories:
     - system
 dependencies:
-  - config_encoder_filters
+  - jtyr.config_encoder_filters


### PR DESCRIPTION
When installed from Ansible Galaxy, this role's dependency fails to
resolve because the dependency's name isn't prefixed with the author
username.

This commit fixes the bug so the role can be used from Galaxy.